### PR TITLE
Add requirements, license, and usage docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ MedianBlur(中值濾波): [python-opencv 中值滤波{cv2.medianBlur(src, ksize)
 
 Tesseract\_OCR: [tesseract-ocr/tesseract: Tesseract Open Source OCR Engine](https://github.com/tesseract-ocr/tesseract)
 
+## Installation
+
+1. 建議先建立 Python 虛擬環境 (可選)。
+2. 安裝本專案所需的套件：
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. 另外需安裝 [Tesseract OCR](https://github.com/tesseract-ocr/tesseract)。安裝後，如有需要，可在 `Preprocessing.py` 中修改 `pytesseract.pytesseract.tesseract_cmd` 的路徑。
+
+## Usage
+
+執行主程式並依照畫面指示操作：
+
+```bash
+python CaptchaBreaker.py
+```
+
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+opencv-python
+pytesseract
+matplotlib


### PR DESCRIPTION
## Summary
- add Python package requirements
- include MIT license
- document installation and usage steps in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68546c859f80832babd60f05055ccd31