### PR TITLE
Allow configuring tesseract path

### DIFF
--- a/Preprocessing.py
+++ b/Preprocessing.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytesseract
 import cv2
+import os
 
 
 # Binarisation & Noise Removal
@@ -59,7 +60,9 @@ def return_image(original_image):
 
 
 def tesseract(given_image):
-    pytesseract.pytesseract.tesseract_cmd = r'C:\Program Files\Tesseract-OCR\tesseract'
+    cmd = os.getenv('TESSERACT_CMD')
+    if cmd:
+        pytesseract.pytesseract.tesseract_cmd = cmd
     return pytesseract.image_to_string(given_image, lang='eng')
 
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ label為檔案名稱(在使用Show success rate for dataset時拿來比對正確
 ![Aspose Words a18e4c6e-9999-40b4-af90-b957a83afeea 008](https://github.com/lukeyu1025/CaptchaReader/assets/74660025/0cbf13b9-442d-4de0-8122-fc8cb77b4ee1)
 
 - **def tesseract(givin\_image):** 使用tesseract將預處理最後的圖片做辨識。
+- 可以透過環境變數 `TESSERACT_CMD` 指定 tesseract 執行檔位置，未設定時將由 `pytesseract` 自行搜尋。
 
 **實驗結果:**
 


### PR DESCRIPTION
## Summary
- allow overriding pytesseract executable via `TESSERACT_CMD`
- document the environment variable in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68546c7da65c832b8840422b462f2da8